### PR TITLE
fix: 'port' must be a number!

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Below is an example of an mqttObject containing the basic properties for a switc
 ```json
 {
   "host": "127.0.0.1",
-  "port": "1883",
+  "port": 1883,
   
   "credentials": {
     "username": "yourUsername",


### PR DESCRIPTION
Copying and pasting the sample config will fail to enable MQTT.