### PR TITLE
Clarified statusPattern readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,16 @@ Then you could use the following pattern:
     "statusPattern": "{\n    \"perRequestRandomValue\": [0-9]+,\n    \"switchState\": true\n}"
 }
 ```
+**Note:** The `statusPattern` must be placed on the same level as the `statusUrl` property, not inside the `statusUrl` object. See below for example.
+
+```json
+{
+    "statusUrl": {
+     },
+    "statusPattern": "....",
+}
+```
+
 More on how to build regex patterns: https://www.w3schools.com/jsref/jsref_obj_regexp.asp
 
 ## Notification Server

--- a/README.md
+++ b/README.md
@@ -419,8 +419,6 @@ could specify the following pattern:
 }
 ```
 
-<br>
-
 However using Regular Expressions much more complex patterns are possible. Let's assume your http enabled device responds 
 with the following json string as body, where one property has an random value an the other indicates the status of the 
 switch:


### PR DESCRIPTION
I added a note to the statusPattern readme section explaining that the statusPattern must reside outside statusUrl object in case it wasn't clear to some people.